### PR TITLE
Fix: end key not working in Arch

### DIFF
--- a/keys.zsh
+++ b/keys.zsh
@@ -7,6 +7,7 @@ bindkey "^[[6~" down-line-or-history
 bindkey '^[[A' up-line-or-search
 bindkey '^[[B' down-line-or-search
 bindkey "^[[H" beginning-of-line
+bindkey "^[[F" end-of-line
 bindkey "^[[1~" beginning-of-line
 bindkey "^[OH" beginning-of-line
 bindkey "^[[4~" end-of-line


### PR DESCRIPTION
End is ^[OF in Ubuntu, ^[[F in Arch.