### PR TITLE
Fix incorrect tab complete suggestion

### DIFF
--- a/completion.zsh
+++ b/completion.zsh
@@ -13,7 +13,7 @@ if [ "x$CASE_SENSITIVE" = "xtrue" ]; then
   zstyle ':completion:*' matcher-list 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
   unset CASE_SENSITIVE
 else
-  zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+  zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
 fi
 
 zstyle ':completion:*' list-colors ''


### PR DESCRIPTION
Tab completion does not give correct suggestions. 

The problem has allegedly been reported and fixed. However, current zsh (5.9) does not have this fix. Ref:
- https://www.reddit.com/r/zsh/comments/10gtr7y/comment/j59jeut/
- https://www.zsh.org/mla/workers/2022/msg01205.html
- https://www.zsh.org/mla/workers/2022/msg00655.html

Description for reproduction from: https://www.zsh.org/mla/workers/2022/msg01205.html

Steps to reproduce:
Type these commands in the terminal:
```
$ touch o-st o-te
$ ls o-
```
Now hit <TAB>, the terminal becomes:
```
$ ls o-T
```
Hit <TAB> again, the terminal becomes:
```
$ ls o-te
```
